### PR TITLE
Fix failing to list attachments on new window.

### DIFF
--- a/api/implementation.js
+++ b/api/implementation.js
@@ -14,8 +14,14 @@ var oabeApi = class extends ExtensionCommon.ExtensionAPI {
       contentType: attachment.contentType,
     })
 
+    // known windowType:
+    // `mail:3pane` main window
+    // `mail:messageWindow` new window
+    // we need a top most (active) window
+    const getMailWindow = () => Services.wm.getMostRecentWindow(null)
+
     const getAttachmentsInActiveMail = () => {
-      const { currentAttachment, currentAttachments } = Services.wm.getMostRecentWindow("mail:3pane")
+      const { currentAttachment, currentAttachments } = getMailWindow()
       return currentAttachment || currentAttachments
     }
 
@@ -39,7 +45,7 @@ var oabeApi = class extends ExtensionCommon.ExtensionAPI {
         // test:
         // await browser.oabeApi.openAttachmentFromActiveMail({name:"TB_1.dxf"})
         async openAttachmentFromActiveMail(filters, options) {
-          const { messenger, setTimeout } = Services.wm.getMostRecentWindow("mail:3pane")
+          const { messenger, setTimeout } = getMailWindow()
           const sleepAsync = (milli) => {
             return new Promise(resolve => {
               setTimeout(() => resolve(), milli)
@@ -112,7 +118,7 @@ var oabeApi = class extends ExtensionCommon.ExtensionAPI {
         async pickFile() {
           const nsIFilePicker = Components.interfaces.nsIFilePicker;
           const fp = newFilePicker()
-          const { window } = Services.wm.getMostRecentWindow("mail:3pane")
+          const { window } = getMailWindow()
           fp.init(window, "OpenAttachmentByExtension", nsIFilePicker.modeOpen)
           fp.appendFilters(nsIFilePicker.filterAll)
           const asyncOpen = new Promise((resolve, reject) => {
@@ -133,7 +139,7 @@ var oabeApi = class extends ExtensionCommon.ExtensionAPI {
         async pickDir() {
           const nsIFilePicker = Components.interfaces.nsIFilePicker;
           const fp = newFilePicker()
-          const { window } = Services.wm.getMostRecentWindow("mail:3pane")
+          const { window } = getMailWindow()
           fp.init(window, "OpenAttachmentByExtension", nsIFilePicker.modeGetFolder)
           fp.appendFilters(nsIFilePicker.filterAll)
           const asyncOpen = new Promise((resolve, reject) => {


### PR DESCRIPTION
If there is only a new window, it seems to return `null` for `getMostRecentWindow("mail:3pane")`

![](https://user-images.githubusercontent.com/5955540/81082074-bae39a00-8f2d-11ea-8914-32ad40dd6780.png)

[getMostRecentWindow()](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIWindowMediator#getMostRecentWindow()) says:

> aWindowType
> Return the topmost window of this type. ("type" is the |windowtype| attribute of the XML <window> element.) If null, return the topmost window of any type.

Thus trying: `Services.wm.getMostRecentWindow(null)`

Fix #5 