### PR TITLE
Use Services global variable if possible

### DIFF
--- a/src/api/implementation.js
+++ b/src/api/implementation.js
@@ -1,7 +1,9 @@
 var oabeApi = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {
     const { FileUtils } = ChromeUtils.import("resource://gre/modules/FileUtils.jsm")
-    const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm")
+    const Services = globalThis.Services || ChromeUtils.import(
+      "resource://gre/modules/Services.jsm"
+    ).Services
     const newProcess = () => Components.classes["@mozilla.org/process/util;1"]
       .createInstance(Components.interfaces.nsIProcess)
     const newFilePicker = () => Components.classes["@mozilla.org/filepicker;1"]


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.